### PR TITLE
Use a separate dt parameter for each signal dimension

### DIFF
--- a/test_sashimi.py
+++ b/test_sashimi.py
@@ -92,7 +92,7 @@ class TestSashimiComponents(unittest.TestCase):
         u = torch.randn(L, 2)
         o = s4(u)
         f = s4.get_recurrent_runner()
-        o2 = torch.cat([f(i) for i in u])
+        o2 = torch.stack([f(i) for i in u])
         self.assertTrue(torch.allclose(o, o2, atol=1e-5, rtol=1e-5))
 
     def test_priming(self):


### PR DESCRIPTION
The model learns a single `log_step` parameter that is used in all signal dimensions right now. This PR creates a separate `log_step` parameter for each signal dimension.

In recurrent mode, this leads to separate A and B matrices for each dimension. Many changes were made to accommodate this. This will also make it possible to learn separate Lambda, P and B parameters for each signal dimension in the future.

Drawbacks:
- About 2.5 times slower in recurrent mode, although convolutional mode is not affected in a meaningful way.
- More memory usage.

Experiments continue. We will see if this improves NLL and sample quality.